### PR TITLE
Fix capitalization in blog title

### DIFF
--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -1,7 +1,7 @@
 {% load staticfiles %}
 <html>
     <head>
-        <title>Django Girls blog</title>
+        <title>Django Girls Blog</title>
 		    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css">
         <link href="//fonts.googleapis.com/css?family=Lobster&subset=latin,latin-ext" rel="stylesheet" type="text/css">


### PR DESCRIPTION
## Summary
- update base template to capitalize Blog title

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*